### PR TITLE
Fix bug with multiple backends on the same host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG ARCH="amd64"
 ARG OS="linux"
-FROM        quay.io/prometheus/busybox:latest
+FROM quay.io/prometheus/busybox:latest
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
 ARG ARCH="amd64"

--- a/haproxy_exporter.go
+++ b/haproxy_exporter.go
@@ -63,7 +63,7 @@ const (
 var (
 	frontendLabelNames = []string{"frontend"}
 	backendLabelNames  = []string{"backend"}
-	serverLabelNames   = []string{"backend", "server"}
+	serverLabelNames   = []string{"backend", "sid", "server"}
 )
 
 func newFrontendMetric(metricName string, docString string, constLabels prometheus.Labels) *prometheus.Desc {
@@ -355,7 +355,7 @@ func (e *Exporter) parseRow(csvRow []string, ch chan<- prometheus.Metric) {
 		return
 	}
 
-	pxname, svname, typ := csvRow[0], csvRow[1], csvRow[32]
+	pxname, svname, sid, typ := csvRow[0], csvRow[1], csvRow[28], csvRow[32]
 
 	const (
 		frontend = "0"
@@ -369,7 +369,7 @@ func (e *Exporter) parseRow(csvRow []string, ch chan<- prometheus.Metric) {
 	case backend:
 		e.exportCsvFields(backendMetrics, csvRow, ch, pxname)
 	case server:
-		e.exportCsvFields(e.serverMetrics, csvRow, ch, pxname, svname)
+		e.exportCsvFields(e.serverMetrics, csvRow, ch, pxname, sid, svname)
 	}
 }
 

--- a/haproxy_exporter_test.go
+++ b/haproxy_exporter_test.go
@@ -116,6 +116,26 @@ foo,BACKEND,0,0,0,0,,0,0,0,,0,,0,0,0,0,UP,1,1,0,0,0,5007,0,,1,8,1,,0,,2,
 	expectMetrics(t, e, "older_haproxy_versions.metrics")
 }
 
+func TestDuplicatedBackendServers(t *testing.T) {
+	const data = `service-0,FRONTEND,,,0,0,10000,0,0,0,0,0,0,,,,,OPEN,,,,,,,,,1,25,0,,,,0,0,0,0,,,,0,0,0,0,0,0,,0,0,0,,,0,0,0,0,,,,,,,,,,,,,,,,,,,,,http,,0,0,0,0,0,0,
+service-0,service-0-server-0,0,0,0,0,,0,0,0,,0,,0,0,0,0,DOWN,1,1,0,0,1,135,135,,1,363,14908,,0,,2,0,,0,L4CON,,0,0,0,0,0,0,0,,,,,0,0,,,,,-1,Connection refused,,0,0,0,0,,,,Layer4 connection problem,,2,6,0,,,,,,http,,,,,,,,
+service-0,service-0-server-1,0,0,0,0,,0,0,0,,0,,0,0,0,0,DOWN,1,1,0,1,1,135,135,,1,363,1498,,0,,2,0,,0,L4CON,,0,0,0,0,0,0,0,,,,,0,0,,,,,-1,Connection refused,,0,0,0,0,,,,Layer4 connection problem,,2,6,0,,,,,,http,,,,,,,,
+service-0,service-0-server-1,0,0,0,0,,0,0,0,,0,,0,0,0,0,DOWN,1,1,0,0,1,135,135,,1,363,25913,,0,,2,0,,0,L4CON,,0,0,0,0,0,0,0,,,,,0,0,,,,,-1,Connection refused,,0,0,0,0,,,,Layer4 connection problem,,2,6,0,,,,,,http,,,,,,,,
+service-0,service-0-server-1,0,0,0,0,,0,0,0,,0,,0,0,0,0,DOWN,1,1,0,1,1,135,135,,1,363,1200,,0,,2,0,,0,L4CON,,0,0,0,0,0,0,0,,,,,0,0,,,,,-1,Connection refused,,0,0,0,0,,,,Layer4 connection problem,,2,6,0,,,,,,http,,,,,,,,
+service-0,service-0-server-1,0,0,0,0,,0,0,0,,0,,0,0,0,0,DOWN,1,1,0,0,1,135,135,,1,363,2371,,0,,2,0,,0,L4CON,,0,0,0,0,0,0,0,,,,,0,0,,,,,-1,Connection refused,,0,0,0,0,,,,Layer4 connection problem,,2,6,0,,,,,,http,,,,,,,,
+service-0,service-0-server-2,0,0,0,0,,0,0,0,,0,,0,0,0,0,DOWN,1,1,0,1,1,135,135,,1,363,26277,,0,,2,0,,0,L4CON,,0,0,0,0,0,0,0,,,,,0,0,,,,,-1,Connection refused,,0,0,0,0,,,,Layer4 connection problem,,2,6,0,,,,,,http,,,,,,,,
+service-0,service-0-server-3,0,0,0,0,,0,0,0,,0,,0,0,0,0,DOWN,1,1,0,0,1,135,135,,1,363,20477,,0,,2,0,,0,L4CON,,0,0,0,0,0,0,0,,,,,0,0,,,,,-1,Connection refused,,0,0,0,0,,,,Layer4 connection problem,,2,6,0,,,,,,http,,,,,,,,
+service-0,BACKEND,0,0,0,0,3000,0,0,0,0,0,,0,0,0,0,DOWN,0,0,0,,1,134,134,,1,363,0,,0,,1,0,,0,,,,0,0,0,0,0,0,,,,0,0,0,0,0,0,0,-1,,,0,0,0,0,,,,,,,,,,,,,,http,,,,,,,,
+`
+
+	h := newHaproxy([]byte(data))
+	defer h.Close()
+
+	e, _ := NewExporter(h.URL, true, serverMetrics, 5*time.Second, log.NewNopLogger())
+
+	expectMetrics(t, e, "duplicated_backend_servers.metrics")
+}
+
 func TestConfigChangeDetection(t *testing.T) {
 	h := newHaproxy([]byte(""))
 	defer h.Close()

--- a/test/duplicated_backend_servers.metrics
+++ b/test/duplicated_backend_servers.metrics
@@ -1,0 +1,369 @@
+# HELP haproxy_backend_bytes_in_total Current total of incoming bytes.
+# TYPE haproxy_backend_bytes_in_total gauge
+haproxy_backend_bytes_in_total{backend="service-0"} 0
+# HELP haproxy_backend_bytes_out_total Current total of outgoing bytes.
+# TYPE haproxy_backend_bytes_out_total gauge
+haproxy_backend_bytes_out_total{backend="service-0"} 0
+# HELP haproxy_backend_compressor_bytes_bypassed_total Number of bytes that bypassed the HTTP compressor
+# TYPE haproxy_backend_compressor_bytes_bypassed_total gauge
+haproxy_backend_compressor_bytes_bypassed_total{backend="service-0"} 0
+# HELP haproxy_backend_compressor_bytes_in_total Number of HTTP response bytes fed to the compressor
+# TYPE haproxy_backend_compressor_bytes_in_total gauge
+haproxy_backend_compressor_bytes_in_total{backend="service-0"} 0
+# HELP haproxy_backend_compressor_bytes_out_total Number of HTTP response bytes emitted by the compressor
+# TYPE haproxy_backend_compressor_bytes_out_total gauge
+haproxy_backend_compressor_bytes_out_total{backend="service-0"} 0
+# HELP haproxy_backend_connection_errors_total Total of connection errors.
+# TYPE haproxy_backend_connection_errors_total gauge
+haproxy_backend_connection_errors_total{backend="service-0"} 0
+# HELP haproxy_backend_current_queue Current number of queued requests not assigned to any server.
+# TYPE haproxy_backend_current_queue gauge
+haproxy_backend_current_queue{backend="service-0"} 0
+# HELP haproxy_backend_current_server Current number of active servers
+# TYPE haproxy_backend_current_server gauge
+haproxy_backend_current_server{backend="service-0"} 0
+# HELP haproxy_backend_current_session_rate Current number of sessions per second over last elapsed second.
+# TYPE haproxy_backend_current_session_rate gauge
+haproxy_backend_current_session_rate{backend="service-0"} 0
+# HELP haproxy_backend_current_sessions Current number of active sessions.
+# TYPE haproxy_backend_current_sessions gauge
+haproxy_backend_current_sessions{backend="service-0"} 0
+# HELP haproxy_backend_http_connect_time_average_seconds Avg. HTTP connect time for last 1024 successful connections.
+# TYPE haproxy_backend_http_connect_time_average_seconds gauge
+haproxy_backend_http_connect_time_average_seconds{backend="service-0"} 0
+# HELP haproxy_backend_http_queue_time_average_seconds Avg. HTTP queue time for last 1024 successful connections.
+# TYPE haproxy_backend_http_queue_time_average_seconds gauge
+haproxy_backend_http_queue_time_average_seconds{backend="service-0"} 0
+# HELP haproxy_backend_http_response_time_average_seconds Avg. HTTP response time for last 1024 successful connections.
+# TYPE haproxy_backend_http_response_time_average_seconds gauge
+haproxy_backend_http_response_time_average_seconds{backend="service-0"} 0
+# HELP haproxy_backend_http_responses_compressed_total Number of HTTP responses that were compressed
+# TYPE haproxy_backend_http_responses_compressed_total gauge
+haproxy_backend_http_responses_compressed_total{backend="service-0"} 0
+# HELP haproxy_backend_http_responses_total Total of HTTP responses.
+# TYPE haproxy_backend_http_responses_total gauge
+haproxy_backend_http_responses_total{backend="service-0",code="1xx"} 0
+haproxy_backend_http_responses_total{backend="service-0",code="2xx"} 0
+haproxy_backend_http_responses_total{backend="service-0",code="3xx"} 0
+haproxy_backend_http_responses_total{backend="service-0",code="4xx"} 0
+haproxy_backend_http_responses_total{backend="service-0",code="5xx"} 0
+haproxy_backend_http_responses_total{backend="service-0",code="other"} 0
+# HELP haproxy_backend_http_total_time_average_seconds Avg. HTTP total time for last 1024 successful connections.
+# TYPE haproxy_backend_http_total_time_average_seconds gauge
+haproxy_backend_http_total_time_average_seconds{backend="service-0"} 0
+# HELP haproxy_backend_limit_sessions Configured session limit.
+# TYPE haproxy_backend_limit_sessions gauge
+haproxy_backend_limit_sessions{backend="service-0"} 3000
+# HELP haproxy_backend_max_queue Maximum observed number of queued requests not assigned to any server.
+# TYPE haproxy_backend_max_queue gauge
+haproxy_backend_max_queue{backend="service-0"} 0
+# HELP haproxy_backend_max_session_rate Maximum number of sessions per second.
+# TYPE haproxy_backend_max_session_rate gauge
+haproxy_backend_max_session_rate{backend="service-0"} 0
+# HELP haproxy_backend_max_sessions Maximum observed number of active sessions.
+# TYPE haproxy_backend_max_sessions gauge
+haproxy_backend_max_sessions{backend="service-0"} 0
+# HELP haproxy_backend_redispatch_warnings_total Total of redispatch warnings.
+# TYPE haproxy_backend_redispatch_warnings_total gauge
+haproxy_backend_redispatch_warnings_total{backend="service-0"} 0
+# HELP haproxy_backend_response_errors_total Total of response errors.
+# TYPE haproxy_backend_response_errors_total gauge
+haproxy_backend_response_errors_total{backend="service-0"} 0
+# HELP haproxy_backend_retry_warnings_total Total of retry warnings.
+# TYPE haproxy_backend_retry_warnings_total gauge
+haproxy_backend_retry_warnings_total{backend="service-0"} 0
+# HELP haproxy_backend_server_selected_total Total number of times a server was selected, either for new sessions, or when re-dispatching.
+# TYPE haproxy_backend_server_selected_total gauge
+haproxy_backend_server_selected_total{backend="service-0"} 0
+# HELP haproxy_backend_sessions_total Total number of sessions.
+# TYPE haproxy_backend_sessions_total gauge
+haproxy_backend_sessions_total{backend="service-0"} 0
+# HELP haproxy_backend_up Current health status of the backend (1 = UP, 0 = DOWN).
+# TYPE haproxy_backend_up gauge
+haproxy_backend_up{backend="service-0"} 0
+# HELP haproxy_backend_weight Total weight of the servers in the backend.
+# TYPE haproxy_backend_weight gauge
+haproxy_backend_weight{backend="service-0"} 0
+# HELP haproxy_exporter_csv_parse_failures Number of errors while parsing CSV.
+# TYPE haproxy_exporter_csv_parse_failures counter
+haproxy_exporter_csv_parse_failures 0
+# HELP haproxy_exporter_total_scrapes Current total HAProxy scrapes.
+# TYPE haproxy_exporter_total_scrapes counter
+haproxy_exporter_total_scrapes 1
+# HELP haproxy_frontend_bytes_in_total Current total of incoming bytes.
+# TYPE haproxy_frontend_bytes_in_total gauge
+haproxy_frontend_bytes_in_total{frontend="service-0"} 0
+# HELP haproxy_frontend_bytes_out_total Current total of outgoing bytes.
+# TYPE haproxy_frontend_bytes_out_total gauge
+haproxy_frontend_bytes_out_total{frontend="service-0"} 0
+# HELP haproxy_frontend_compressor_bytes_bypassed_total Number of bytes that bypassed the HTTP compressor
+# TYPE haproxy_frontend_compressor_bytes_bypassed_total gauge
+haproxy_frontend_compressor_bytes_bypassed_total{frontend="service-0"} 0
+# HELP haproxy_frontend_compressor_bytes_in_total Number of HTTP response bytes fed to the compressor
+# TYPE haproxy_frontend_compressor_bytes_in_total gauge
+haproxy_frontend_compressor_bytes_in_total{frontend="service-0"} 0
+# HELP haproxy_frontend_compressor_bytes_out_total Number of HTTP response bytes emitted by the compressor
+# TYPE haproxy_frontend_compressor_bytes_out_total gauge
+haproxy_frontend_compressor_bytes_out_total{frontend="service-0"} 0
+# HELP haproxy_frontend_connections_total Total number of connections
+# TYPE haproxy_frontend_connections_total gauge
+haproxy_frontend_connections_total{frontend="service-0"} 0
+# HELP haproxy_frontend_current_session_rate Current number of sessions per second over last elapsed second.
+# TYPE haproxy_frontend_current_session_rate gauge
+haproxy_frontend_current_session_rate{frontend="service-0"} 0
+# HELP haproxy_frontend_current_sessions Current number of active sessions.
+# TYPE haproxy_frontend_current_sessions gauge
+haproxy_frontend_current_sessions{frontend="service-0"} 0
+# HELP haproxy_frontend_http_requests_total Total HTTP requests.
+# TYPE haproxy_frontend_http_requests_total gauge
+haproxy_frontend_http_requests_total{frontend="service-0"} 0
+# HELP haproxy_frontend_http_responses_compressed_total Number of HTTP responses that were compressed
+# TYPE haproxy_frontend_http_responses_compressed_total gauge
+haproxy_frontend_http_responses_compressed_total{frontend="service-0"} 0
+# HELP haproxy_frontend_http_responses_total Total of HTTP responses.
+# TYPE haproxy_frontend_http_responses_total gauge
+haproxy_frontend_http_responses_total{code="1xx",frontend="service-0"} 0
+haproxy_frontend_http_responses_total{code="2xx",frontend="service-0"} 0
+haproxy_frontend_http_responses_total{code="3xx",frontend="service-0"} 0
+haproxy_frontend_http_responses_total{code="4xx",frontend="service-0"} 0
+haproxy_frontend_http_responses_total{code="5xx",frontend="service-0"} 0
+haproxy_frontend_http_responses_total{code="other",frontend="service-0"} 0
+# HELP haproxy_frontend_limit_session_rate Configured limit on new sessions per second.
+# TYPE haproxy_frontend_limit_session_rate gauge
+haproxy_frontend_limit_session_rate{frontend="service-0"} 0
+# HELP haproxy_frontend_limit_sessions Configured session limit.
+# TYPE haproxy_frontend_limit_sessions gauge
+haproxy_frontend_limit_sessions{frontend="service-0"} 10000
+# HELP haproxy_frontend_max_session_rate Maximum observed number of sessions per second.
+# TYPE haproxy_frontend_max_session_rate gauge
+haproxy_frontend_max_session_rate{frontend="service-0"} 0
+# HELP haproxy_frontend_max_sessions Maximum observed number of active sessions.
+# TYPE haproxy_frontend_max_sessions gauge
+haproxy_frontend_max_sessions{frontend="service-0"} 0
+# HELP haproxy_frontend_request_errors_total Total of request errors.
+# TYPE haproxy_frontend_request_errors_total gauge
+haproxy_frontend_request_errors_total{frontend="service-0"} 0
+# HELP haproxy_frontend_requests_denied_total Total of requests denied for security.
+# TYPE haproxy_frontend_requests_denied_total gauge
+haproxy_frontend_requests_denied_total{frontend="service-0"} 0
+# HELP haproxy_frontend_sessions_total Total number of sessions.
+# TYPE haproxy_frontend_sessions_total gauge
+haproxy_frontend_sessions_total{frontend="service-0"} 0
+# HELP haproxy_server_bytes_in_total Current total of incoming bytes.
+# TYPE haproxy_server_bytes_in_total gauge
+haproxy_server_bytes_in_total{backend="service-0",server="service-0-server-0",sid="14908"} 0
+haproxy_server_bytes_in_total{backend="service-0",server="service-0-server-1",sid="1200"} 0
+haproxy_server_bytes_in_total{backend="service-0",server="service-0-server-1",sid="1498"} 0
+haproxy_server_bytes_in_total{backend="service-0",server="service-0-server-1",sid="2371"} 0
+haproxy_server_bytes_in_total{backend="service-0",server="service-0-server-1",sid="25913"} 0
+haproxy_server_bytes_in_total{backend="service-0",server="service-0-server-2",sid="26277"} 0
+haproxy_server_bytes_in_total{backend="service-0",server="service-0-server-3",sid="20477"} 0
+# HELP haproxy_server_bytes_out_total Current total of outgoing bytes.
+# TYPE haproxy_server_bytes_out_total gauge
+haproxy_server_bytes_out_total{backend="service-0",server="service-0-server-0",sid="14908"} 0
+haproxy_server_bytes_out_total{backend="service-0",server="service-0-server-1",sid="1200"} 0
+haproxy_server_bytes_out_total{backend="service-0",server="service-0-server-1",sid="1498"} 0
+haproxy_server_bytes_out_total{backend="service-0",server="service-0-server-1",sid="2371"} 0
+haproxy_server_bytes_out_total{backend="service-0",server="service-0-server-1",sid="25913"} 0
+haproxy_server_bytes_out_total{backend="service-0",server="service-0-server-2",sid="26277"} 0
+haproxy_server_bytes_out_total{backend="service-0",server="service-0-server-3",sid="20477"} 0
+# HELP haproxy_server_check_duration_milliseconds Previously run health check duration, in milliseconds
+# TYPE haproxy_server_check_duration_milliseconds gauge
+haproxy_server_check_duration_milliseconds{backend="service-0",server="service-0-server-0",sid="14908"} 0
+haproxy_server_check_duration_milliseconds{backend="service-0",server="service-0-server-1",sid="1200"} 0
+haproxy_server_check_duration_milliseconds{backend="service-0",server="service-0-server-1",sid="1498"} 0
+haproxy_server_check_duration_milliseconds{backend="service-0",server="service-0-server-1",sid="2371"} 0
+haproxy_server_check_duration_milliseconds{backend="service-0",server="service-0-server-1",sid="25913"} 0
+haproxy_server_check_duration_milliseconds{backend="service-0",server="service-0-server-2",sid="26277"} 0
+haproxy_server_check_duration_milliseconds{backend="service-0",server="service-0-server-3",sid="20477"} 0
+# HELP haproxy_server_check_failures_total Total number of failed health checks.
+# TYPE haproxy_server_check_failures_total gauge
+haproxy_server_check_failures_total{backend="service-0",server="service-0-server-0",sid="14908"} 0
+haproxy_server_check_failures_total{backend="service-0",server="service-0-server-1",sid="1200"} 1
+haproxy_server_check_failures_total{backend="service-0",server="service-0-server-1",sid="1498"} 1
+haproxy_server_check_failures_total{backend="service-0",server="service-0-server-1",sid="2371"} 0
+haproxy_server_check_failures_total{backend="service-0",server="service-0-server-1",sid="25913"} 0
+haproxy_server_check_failures_total{backend="service-0",server="service-0-server-2",sid="26277"} 1
+haproxy_server_check_failures_total{backend="service-0",server="service-0-server-3",sid="20477"} 0
+# HELP haproxy_server_connection_errors_total Total of connection errors.
+# TYPE haproxy_server_connection_errors_total gauge
+haproxy_server_connection_errors_total{backend="service-0",server="service-0-server-0",sid="14908"} 0
+haproxy_server_connection_errors_total{backend="service-0",server="service-0-server-1",sid="1200"} 0
+haproxy_server_connection_errors_total{backend="service-0",server="service-0-server-1",sid="1498"} 0
+haproxy_server_connection_errors_total{backend="service-0",server="service-0-server-1",sid="2371"} 0
+haproxy_server_connection_errors_total{backend="service-0",server="service-0-server-1",sid="25913"} 0
+haproxy_server_connection_errors_total{backend="service-0",server="service-0-server-2",sid="26277"} 0
+haproxy_server_connection_errors_total{backend="service-0",server="service-0-server-3",sid="20477"} 0
+# HELP haproxy_server_current_queue Current number of queued requests assigned to this server.
+# TYPE haproxy_server_current_queue gauge
+haproxy_server_current_queue{backend="service-0",server="service-0-server-0",sid="14908"} 0
+haproxy_server_current_queue{backend="service-0",server="service-0-server-1",sid="1200"} 0
+haproxy_server_current_queue{backend="service-0",server="service-0-server-1",sid="1498"} 0
+haproxy_server_current_queue{backend="service-0",server="service-0-server-1",sid="2371"} 0
+haproxy_server_current_queue{backend="service-0",server="service-0-server-1",sid="25913"} 0
+haproxy_server_current_queue{backend="service-0",server="service-0-server-2",sid="26277"} 0
+haproxy_server_current_queue{backend="service-0",server="service-0-server-3",sid="20477"} 0
+# HELP haproxy_server_current_session_rate Current number of sessions per second over last elapsed second.
+# TYPE haproxy_server_current_session_rate gauge
+haproxy_server_current_session_rate{backend="service-0",server="service-0-server-0",sid="14908"} 0
+haproxy_server_current_session_rate{backend="service-0",server="service-0-server-1",sid="1200"} 0
+haproxy_server_current_session_rate{backend="service-0",server="service-0-server-1",sid="1498"} 0
+haproxy_server_current_session_rate{backend="service-0",server="service-0-server-1",sid="2371"} 0
+haproxy_server_current_session_rate{backend="service-0",server="service-0-server-1",sid="25913"} 0
+haproxy_server_current_session_rate{backend="service-0",server="service-0-server-2",sid="26277"} 0
+haproxy_server_current_session_rate{backend="service-0",server="service-0-server-3",sid="20477"} 0
+# HELP haproxy_server_current_sessions Current number of active sessions.
+# TYPE haproxy_server_current_sessions gauge
+haproxy_server_current_sessions{backend="service-0",server="service-0-server-0",sid="14908"} 0
+haproxy_server_current_sessions{backend="service-0",server="service-0-server-1",sid="1200"} 0
+haproxy_server_current_sessions{backend="service-0",server="service-0-server-1",sid="1498"} 0
+haproxy_server_current_sessions{backend="service-0",server="service-0-server-1",sid="2371"} 0
+haproxy_server_current_sessions{backend="service-0",server="service-0-server-1",sid="25913"} 0
+haproxy_server_current_sessions{backend="service-0",server="service-0-server-2",sid="26277"} 0
+haproxy_server_current_sessions{backend="service-0",server="service-0-server-3",sid="20477"} 0
+# HELP haproxy_server_downtime_seconds_total Total downtime in seconds.
+# TYPE haproxy_server_downtime_seconds_total gauge
+haproxy_server_downtime_seconds_total{backend="service-0",server="service-0-server-0",sid="14908"} 135
+haproxy_server_downtime_seconds_total{backend="service-0",server="service-0-server-1",sid="1200"} 135
+haproxy_server_downtime_seconds_total{backend="service-0",server="service-0-server-1",sid="1498"} 135
+haproxy_server_downtime_seconds_total{backend="service-0",server="service-0-server-1",sid="2371"} 135
+haproxy_server_downtime_seconds_total{backend="service-0",server="service-0-server-1",sid="25913"} 135
+haproxy_server_downtime_seconds_total{backend="service-0",server="service-0-server-2",sid="26277"} 135
+haproxy_server_downtime_seconds_total{backend="service-0",server="service-0-server-3",sid="20477"} 135
+# HELP haproxy_server_http_responses_total Total of HTTP responses.
+# TYPE haproxy_server_http_responses_total gauge
+haproxy_server_http_responses_total{backend="service-0",code="1xx",server="service-0-server-0",sid="14908"} 0
+haproxy_server_http_responses_total{backend="service-0",code="1xx",server="service-0-server-1",sid="1200"} 0
+haproxy_server_http_responses_total{backend="service-0",code="1xx",server="service-0-server-1",sid="1498"} 0
+haproxy_server_http_responses_total{backend="service-0",code="1xx",server="service-0-server-1",sid="2371"} 0
+haproxy_server_http_responses_total{backend="service-0",code="1xx",server="service-0-server-1",sid="25913"} 0
+haproxy_server_http_responses_total{backend="service-0",code="1xx",server="service-0-server-2",sid="26277"} 0
+haproxy_server_http_responses_total{backend="service-0",code="1xx",server="service-0-server-3",sid="20477"} 0
+haproxy_server_http_responses_total{backend="service-0",code="2xx",server="service-0-server-0",sid="14908"} 0
+haproxy_server_http_responses_total{backend="service-0",code="2xx",server="service-0-server-1",sid="1200"} 0
+haproxy_server_http_responses_total{backend="service-0",code="2xx",server="service-0-server-1",sid="1498"} 0
+haproxy_server_http_responses_total{backend="service-0",code="2xx",server="service-0-server-1",sid="2371"} 0
+haproxy_server_http_responses_total{backend="service-0",code="2xx",server="service-0-server-1",sid="25913"} 0
+haproxy_server_http_responses_total{backend="service-0",code="2xx",server="service-0-server-2",sid="26277"} 0
+haproxy_server_http_responses_total{backend="service-0",code="2xx",server="service-0-server-3",sid="20477"} 0
+haproxy_server_http_responses_total{backend="service-0",code="3xx",server="service-0-server-0",sid="14908"} 0
+haproxy_server_http_responses_total{backend="service-0",code="3xx",server="service-0-server-1",sid="1200"} 0
+haproxy_server_http_responses_total{backend="service-0",code="3xx",server="service-0-server-1",sid="1498"} 0
+haproxy_server_http_responses_total{backend="service-0",code="3xx",server="service-0-server-1",sid="2371"} 0
+haproxy_server_http_responses_total{backend="service-0",code="3xx",server="service-0-server-1",sid="25913"} 0
+haproxy_server_http_responses_total{backend="service-0",code="3xx",server="service-0-server-2",sid="26277"} 0
+haproxy_server_http_responses_total{backend="service-0",code="3xx",server="service-0-server-3",sid="20477"} 0
+haproxy_server_http_responses_total{backend="service-0",code="4xx",server="service-0-server-0",sid="14908"} 0
+haproxy_server_http_responses_total{backend="service-0",code="4xx",server="service-0-server-1",sid="1200"} 0
+haproxy_server_http_responses_total{backend="service-0",code="4xx",server="service-0-server-1",sid="1498"} 0
+haproxy_server_http_responses_total{backend="service-0",code="4xx",server="service-0-server-1",sid="2371"} 0
+haproxy_server_http_responses_total{backend="service-0",code="4xx",server="service-0-server-1",sid="25913"} 0
+haproxy_server_http_responses_total{backend="service-0",code="4xx",server="service-0-server-2",sid="26277"} 0
+haproxy_server_http_responses_total{backend="service-0",code="4xx",server="service-0-server-3",sid="20477"} 0
+haproxy_server_http_responses_total{backend="service-0",code="5xx",server="service-0-server-0",sid="14908"} 0
+haproxy_server_http_responses_total{backend="service-0",code="5xx",server="service-0-server-1",sid="1200"} 0
+haproxy_server_http_responses_total{backend="service-0",code="5xx",server="service-0-server-1",sid="1498"} 0
+haproxy_server_http_responses_total{backend="service-0",code="5xx",server="service-0-server-1",sid="2371"} 0
+haproxy_server_http_responses_total{backend="service-0",code="5xx",server="service-0-server-1",sid="25913"} 0
+haproxy_server_http_responses_total{backend="service-0",code="5xx",server="service-0-server-2",sid="26277"} 0
+haproxy_server_http_responses_total{backend="service-0",code="5xx",server="service-0-server-3",sid="20477"} 0
+haproxy_server_http_responses_total{backend="service-0",code="other",server="service-0-server-0",sid="14908"} 0
+haproxy_server_http_responses_total{backend="service-0",code="other",server="service-0-server-1",sid="1200"} 0
+haproxy_server_http_responses_total{backend="service-0",code="other",server="service-0-server-1",sid="1498"} 0
+haproxy_server_http_responses_total{backend="service-0",code="other",server="service-0-server-1",sid="2371"} 0
+haproxy_server_http_responses_total{backend="service-0",code="other",server="service-0-server-1",sid="25913"} 0
+haproxy_server_http_responses_total{backend="service-0",code="other",server="service-0-server-2",sid="26277"} 0
+haproxy_server_http_responses_total{backend="service-0",code="other",server="service-0-server-3",sid="20477"} 0
+# HELP haproxy_server_max_queue Maximum observed number of queued requests assigned to this server.
+# TYPE haproxy_server_max_queue gauge
+haproxy_server_max_queue{backend="service-0",server="service-0-server-0",sid="14908"} 0
+haproxy_server_max_queue{backend="service-0",server="service-0-server-1",sid="1200"} 0
+haproxy_server_max_queue{backend="service-0",server="service-0-server-1",sid="1498"} 0
+haproxy_server_max_queue{backend="service-0",server="service-0-server-1",sid="2371"} 0
+haproxy_server_max_queue{backend="service-0",server="service-0-server-1",sid="25913"} 0
+haproxy_server_max_queue{backend="service-0",server="service-0-server-2",sid="26277"} 0
+haproxy_server_max_queue{backend="service-0",server="service-0-server-3",sid="20477"} 0
+# HELP haproxy_server_max_session_rate Maximum observed number of sessions per second.
+# TYPE haproxy_server_max_session_rate gauge
+haproxy_server_max_session_rate{backend="service-0",server="service-0-server-0",sid="14908"} 0
+haproxy_server_max_session_rate{backend="service-0",server="service-0-server-1",sid="1200"} 0
+haproxy_server_max_session_rate{backend="service-0",server="service-0-server-1",sid="1498"} 0
+haproxy_server_max_session_rate{backend="service-0",server="service-0-server-1",sid="2371"} 0
+haproxy_server_max_session_rate{backend="service-0",server="service-0-server-1",sid="25913"} 0
+haproxy_server_max_session_rate{backend="service-0",server="service-0-server-2",sid="26277"} 0
+haproxy_server_max_session_rate{backend="service-0",server="service-0-server-3",sid="20477"} 0
+# HELP haproxy_server_max_sessions Maximum observed number of active sessions.
+# TYPE haproxy_server_max_sessions gauge
+haproxy_server_max_sessions{backend="service-0",server="service-0-server-0",sid="14908"} 0
+haproxy_server_max_sessions{backend="service-0",server="service-0-server-1",sid="1200"} 0
+haproxy_server_max_sessions{backend="service-0",server="service-0-server-1",sid="1498"} 0
+haproxy_server_max_sessions{backend="service-0",server="service-0-server-1",sid="2371"} 0
+haproxy_server_max_sessions{backend="service-0",server="service-0-server-1",sid="25913"} 0
+haproxy_server_max_sessions{backend="service-0",server="service-0-server-2",sid="26277"} 0
+haproxy_server_max_sessions{backend="service-0",server="service-0-server-3",sid="20477"} 0
+# HELP haproxy_server_redispatch_warnings_total Total of redispatch warnings.
+# TYPE haproxy_server_redispatch_warnings_total gauge
+haproxy_server_redispatch_warnings_total{backend="service-0",server="service-0-server-0",sid="14908"} 0
+haproxy_server_redispatch_warnings_total{backend="service-0",server="service-0-server-1",sid="1200"} 0
+haproxy_server_redispatch_warnings_total{backend="service-0",server="service-0-server-1",sid="1498"} 0
+haproxy_server_redispatch_warnings_total{backend="service-0",server="service-0-server-1",sid="2371"} 0
+haproxy_server_redispatch_warnings_total{backend="service-0",server="service-0-server-1",sid="25913"} 0
+haproxy_server_redispatch_warnings_total{backend="service-0",server="service-0-server-2",sid="26277"} 0
+haproxy_server_redispatch_warnings_total{backend="service-0",server="service-0-server-3",sid="20477"} 0
+# HELP haproxy_server_response_errors_total Total of response errors.
+# TYPE haproxy_server_response_errors_total gauge
+haproxy_server_response_errors_total{backend="service-0",server="service-0-server-0",sid="14908"} 0
+haproxy_server_response_errors_total{backend="service-0",server="service-0-server-1",sid="1200"} 0
+haproxy_server_response_errors_total{backend="service-0",server="service-0-server-1",sid="1498"} 0
+haproxy_server_response_errors_total{backend="service-0",server="service-0-server-1",sid="2371"} 0
+haproxy_server_response_errors_total{backend="service-0",server="service-0-server-1",sid="25913"} 0
+haproxy_server_response_errors_total{backend="service-0",server="service-0-server-2",sid="26277"} 0
+haproxy_server_response_errors_total{backend="service-0",server="service-0-server-3",sid="20477"} 0
+# HELP haproxy_server_retry_warnings_total Total of retry warnings.
+# TYPE haproxy_server_retry_warnings_total gauge
+haproxy_server_retry_warnings_total{backend="service-0",server="service-0-server-0",sid="14908"} 0
+haproxy_server_retry_warnings_total{backend="service-0",server="service-0-server-1",sid="1200"} 0
+haproxy_server_retry_warnings_total{backend="service-0",server="service-0-server-1",sid="1498"} 0
+haproxy_server_retry_warnings_total{backend="service-0",server="service-0-server-1",sid="2371"} 0
+haproxy_server_retry_warnings_total{backend="service-0",server="service-0-server-1",sid="25913"} 0
+haproxy_server_retry_warnings_total{backend="service-0",server="service-0-server-2",sid="26277"} 0
+haproxy_server_retry_warnings_total{backend="service-0",server="service-0-server-3",sid="20477"} 0
+# HELP haproxy_server_server_selected_total Total number of times a server was selected, either for new sessions, or when re-dispatching.
+# TYPE haproxy_server_server_selected_total gauge
+haproxy_server_server_selected_total{backend="service-0",server="service-0-server-0",sid="14908"} 0
+haproxy_server_server_selected_total{backend="service-0",server="service-0-server-1",sid="1200"} 0
+haproxy_server_server_selected_total{backend="service-0",server="service-0-server-1",sid="1498"} 0
+haproxy_server_server_selected_total{backend="service-0",server="service-0-server-1",sid="2371"} 0
+haproxy_server_server_selected_total{backend="service-0",server="service-0-server-1",sid="25913"} 0
+haproxy_server_server_selected_total{backend="service-0",server="service-0-server-2",sid="26277"} 0
+haproxy_server_server_selected_total{backend="service-0",server="service-0-server-3",sid="20477"} 0
+# HELP haproxy_server_sessions_total Total number of sessions.
+# TYPE haproxy_server_sessions_total gauge
+haproxy_server_sessions_total{backend="service-0",server="service-0-server-0",sid="14908"} 0
+haproxy_server_sessions_total{backend="service-0",server="service-0-server-1",sid="1200"} 0
+haproxy_server_sessions_total{backend="service-0",server="service-0-server-1",sid="1498"} 0
+haproxy_server_sessions_total{backend="service-0",server="service-0-server-1",sid="2371"} 0
+haproxy_server_sessions_total{backend="service-0",server="service-0-server-1",sid="25913"} 0
+haproxy_server_sessions_total{backend="service-0",server="service-0-server-2",sid="26277"} 0
+haproxy_server_sessions_total{backend="service-0",server="service-0-server-3",sid="20477"} 0
+# HELP haproxy_server_up Current health status of the server (1 = UP, 0 = DOWN).
+# TYPE haproxy_server_up gauge
+haproxy_server_up{backend="service-0",server="service-0-server-0",sid="14908"} 0
+haproxy_server_up{backend="service-0",server="service-0-server-1",sid="1200"} 0
+haproxy_server_up{backend="service-0",server="service-0-server-1",sid="1498"} 0
+haproxy_server_up{backend="service-0",server="service-0-server-1",sid="2371"} 0
+haproxy_server_up{backend="service-0",server="service-0-server-1",sid="25913"} 0
+haproxy_server_up{backend="service-0",server="service-0-server-2",sid="26277"} 0
+haproxy_server_up{backend="service-0",server="service-0-server-3",sid="20477"} 0
+# HELP haproxy_server_weight Current weight of the server.
+# TYPE haproxy_server_weight gauge
+haproxy_server_weight{backend="service-0",server="service-0-server-0",sid="14908"} 1
+haproxy_server_weight{backend="service-0",server="service-0-server-1",sid="1200"} 1
+haproxy_server_weight{backend="service-0",server="service-0-server-1",sid="1498"} 1
+haproxy_server_weight{backend="service-0",server="service-0-server-1",sid="2371"} 1
+haproxy_server_weight{backend="service-0",server="service-0-server-1",sid="25913"} 1
+haproxy_server_weight{backend="service-0",server="service-0-server-2",sid="26277"} 1
+haproxy_server_weight{backend="service-0",server="service-0-server-3",sid="20477"} 1
+# HELP haproxy_up Was the last scrape of haproxy successful.
+# TYPE haproxy_up gauge
+haproxy_up 1

--- a/test/older_haproxy_versions.metrics
+++ b/test/older_haproxy_versions.metrics
@@ -6,84 +6,84 @@ haproxy_exporter_csv_parse_failures 0
 haproxy_exporter_total_scrapes 1
 # HELP haproxy_server_bytes_in_total Current total of incoming bytes.
 # TYPE haproxy_server_bytes_in_total gauge
-haproxy_server_bytes_in_total{backend="foo",server="BACKEND"} 0
-haproxy_server_bytes_in_total{backend="foo",server="FRONTEND"} 0
-haproxy_server_bytes_in_total{backend="foo",server="foo-instance-0"} 0
+haproxy_server_bytes_in_total{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_bytes_in_total{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_bytes_in_total{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_bytes_out_total Current total of outgoing bytes.
 # TYPE haproxy_server_bytes_out_total gauge
-haproxy_server_bytes_out_total{backend="foo",server="BACKEND"} 0
-haproxy_server_bytes_out_total{backend="foo",server="FRONTEND"} 0
-haproxy_server_bytes_out_total{backend="foo",server="foo-instance-0"} 0
+haproxy_server_bytes_out_total{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_bytes_out_total{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_bytes_out_total{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_check_failures_total Total number of failed health checks.
 # TYPE haproxy_server_check_failures_total gauge
-haproxy_server_check_failures_total{backend="foo",server="BACKEND"} 0
-haproxy_server_check_failures_total{backend="foo",server="FRONTEND"} 0
-haproxy_server_check_failures_total{backend="foo",server="foo-instance-0"} 0
+haproxy_server_check_failures_total{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_check_failures_total{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_check_failures_total{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_connection_errors_total Total of connection errors.
 # TYPE haproxy_server_connection_errors_total gauge
-haproxy_server_connection_errors_total{backend="foo",server="BACKEND"} 0
-haproxy_server_connection_errors_total{backend="foo",server="FRONTEND"} 0
-haproxy_server_connection_errors_total{backend="foo",server="foo-instance-0"} 0
+haproxy_server_connection_errors_total{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_connection_errors_total{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_connection_errors_total{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_current_queue Current number of queued requests assigned to this server.
 # TYPE haproxy_server_current_queue gauge
-haproxy_server_current_queue{backend="foo",server="BACKEND"} 0
-haproxy_server_current_queue{backend="foo",server="FRONTEND"} 0
-haproxy_server_current_queue{backend="foo",server="foo-instance-0"} 0
+haproxy_server_current_queue{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_current_queue{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_current_queue{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_current_sessions Current number of active sessions.
 # TYPE haproxy_server_current_sessions gauge
-haproxy_server_current_sessions{backend="foo",server="BACKEND"} 0
-haproxy_server_current_sessions{backend="foo",server="FRONTEND"} 0
-haproxy_server_current_sessions{backend="foo",server="foo-instance-0"} 0
+haproxy_server_current_sessions{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_current_sessions{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_current_sessions{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_downtime_seconds_total Total downtime in seconds.
 # TYPE haproxy_server_downtime_seconds_total gauge
-haproxy_server_downtime_seconds_total{backend="foo",server="BACKEND"} 0
-haproxy_server_downtime_seconds_total{backend="foo",server="FRONTEND"} 0
-haproxy_server_downtime_seconds_total{backend="foo",server="foo-instance-0"} 0
+haproxy_server_downtime_seconds_total{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_downtime_seconds_total{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_downtime_seconds_total{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_max_queue Maximum observed number of queued requests assigned to this server.
 # TYPE haproxy_server_max_queue gauge
-haproxy_server_max_queue{backend="foo",server="BACKEND"} 0
-haproxy_server_max_queue{backend="foo",server="FRONTEND"} 0
-haproxy_server_max_queue{backend="foo",server="foo-instance-0"} 0
+haproxy_server_max_queue{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_max_queue{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_max_queue{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_max_sessions Maximum observed number of active sessions.
 # TYPE haproxy_server_max_sessions gauge
-haproxy_server_max_sessions{backend="foo",server="BACKEND"} 0
-haproxy_server_max_sessions{backend="foo",server="FRONTEND"} 0
-haproxy_server_max_sessions{backend="foo",server="foo-instance-0"} 0
+haproxy_server_max_sessions{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_max_sessions{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_max_sessions{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_redispatch_warnings_total Total of redispatch warnings.
 # TYPE haproxy_server_redispatch_warnings_total gauge
-haproxy_server_redispatch_warnings_total{backend="foo",server="BACKEND"} 0
-haproxy_server_redispatch_warnings_total{backend="foo",server="FRONTEND"} 0
-haproxy_server_redispatch_warnings_total{backend="foo",server="foo-instance-0"} 0
+haproxy_server_redispatch_warnings_total{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_redispatch_warnings_total{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_redispatch_warnings_total{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_response_errors_total Total of response errors.
 # TYPE haproxy_server_response_errors_total gauge
-haproxy_server_response_errors_total{backend="foo",server="BACKEND"} 0
-haproxy_server_response_errors_total{backend="foo",server="FRONTEND"} 0
-haproxy_server_response_errors_total{backend="foo",server="foo-instance-0"} 0
+haproxy_server_response_errors_total{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_response_errors_total{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_response_errors_total{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_retry_warnings_total Total of retry warnings.
 # TYPE haproxy_server_retry_warnings_total gauge
-haproxy_server_retry_warnings_total{backend="foo",server="BACKEND"} 0
-haproxy_server_retry_warnings_total{backend="foo",server="FRONTEND"} 0
-haproxy_server_retry_warnings_total{backend="foo",server="foo-instance-0"} 0
+haproxy_server_retry_warnings_total{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_retry_warnings_total{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_retry_warnings_total{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_server_selected_total Total number of times a server was selected, either for new sessions, or when re-dispatching.
 # TYPE haproxy_server_server_selected_total gauge
-haproxy_server_server_selected_total{backend="foo",server="BACKEND"} 0
-haproxy_server_server_selected_total{backend="foo",server="FRONTEND"} 0
-haproxy_server_server_selected_total{backend="foo",server="foo-instance-0"} 0
+haproxy_server_server_selected_total{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_server_selected_total{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_server_selected_total{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_sessions_total Total number of sessions.
 # TYPE haproxy_server_sessions_total gauge
-haproxy_server_sessions_total{backend="foo",server="BACKEND"} 0
-haproxy_server_sessions_total{backend="foo",server="FRONTEND"} 0
-haproxy_server_sessions_total{backend="foo",server="foo-instance-0"} 0
+haproxy_server_sessions_total{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_sessions_total{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_sessions_total{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_up Current health status of the server (1 = UP, 0 = DOWN).
 # TYPE haproxy_server_up gauge
-haproxy_server_up{backend="foo",server="BACKEND"} 1
-haproxy_server_up{backend="foo",server="FRONTEND"} 1
-haproxy_server_up{backend="foo",server="foo-instance-0"} 1
+haproxy_server_up{backend="foo",server="BACKEND",sid="1"} 1
+haproxy_server_up{backend="foo",server="FRONTEND",sid="1"} 1
+haproxy_server_up{backend="foo",server="foo-instance-0",sid="1"} 1
 # HELP haproxy_server_weight Current weight of the server.
 # TYPE haproxy_server_weight gauge
-haproxy_server_weight{backend="foo",server="BACKEND"} 1
-haproxy_server_weight{backend="foo",server="FRONTEND"} 1
-haproxy_server_weight{backend="foo",server="foo-instance-0"} 1
+haproxy_server_weight{backend="foo",server="BACKEND",sid="1"} 1
+haproxy_server_weight{backend="foo",server="FRONTEND",sid="1"} 1
+haproxy_server_weight{backend="foo",server="foo-instance-0",sid="1"} 1
 # HELP haproxy_up Was the last scrape of haproxy successful.
 # TYPE haproxy_up gauge
 haproxy_up 1

--- a/test/server_broken_csv.metrics
+++ b/test/server_broken_csv.metrics
@@ -6,99 +6,99 @@ haproxy_exporter_csv_parse_failures 1
 haproxy_exporter_total_scrapes 1
 # HELP haproxy_server_bytes_in_total Current total of incoming bytes.
 # TYPE haproxy_server_bytes_in_total gauge
-haproxy_server_bytes_in_total{backend="foo",server="BACKEND"} 0
-haproxy_server_bytes_in_total{backend="foo",server="FRONTEND"} 0
-haproxy_server_bytes_in_total{backend="foo",server="foo-instance-0"} 0
+haproxy_server_bytes_in_total{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_bytes_in_total{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_bytes_in_total{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_bytes_out_total Current total of outgoing bytes.
 # TYPE haproxy_server_bytes_out_total gauge
-haproxy_server_bytes_out_total{backend="foo",server="BACKEND"} 0
-haproxy_server_bytes_out_total{backend="foo",server="FRONTEND"} 0
-haproxy_server_bytes_out_total{backend="foo",server="foo-instance-0"} 0
+haproxy_server_bytes_out_total{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_bytes_out_total{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_bytes_out_total{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_check_duration_milliseconds Previously run health check duration, in milliseconds
 # TYPE haproxy_server_check_duration_milliseconds gauge
-haproxy_server_check_duration_milliseconds{backend="foo",server="BACKEND"} 0
-haproxy_server_check_duration_milliseconds{backend="foo",server="FRONTEND"} 0
-haproxy_server_check_duration_milliseconds{backend="foo",server="foo-instance-0"} 0
+haproxy_server_check_duration_milliseconds{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_check_duration_milliseconds{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_check_duration_milliseconds{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_check_failures_total Total number of failed health checks.
 # TYPE haproxy_server_check_failures_total gauge
-haproxy_server_check_failures_total{backend="foo",server="BACKEND"} 0
-haproxy_server_check_failures_total{backend="foo",server="FRONTEND"} 0
-haproxy_server_check_failures_total{backend="foo",server="foo-instance-0"} 0
+haproxy_server_check_failures_total{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_check_failures_total{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_check_failures_total{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_connection_errors_total Total of connection errors.
 # TYPE haproxy_server_connection_errors_total gauge
-haproxy_server_connection_errors_total{backend="foo",server="BACKEND"} 0
-haproxy_server_connection_errors_total{backend="foo",server="FRONTEND"} 0
-haproxy_server_connection_errors_total{backend="foo",server="foo-instance-0"} 0
+haproxy_server_connection_errors_total{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_connection_errors_total{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_connection_errors_total{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_current_queue Current number of queued requests assigned to this server.
 # TYPE haproxy_server_current_queue gauge
-haproxy_server_current_queue{backend="foo",server="BACKEND"} 0
-haproxy_server_current_queue{backend="foo",server="FRONTEND"} 0
-haproxy_server_current_queue{backend="foo",server="foo-instance-0"} 0
+haproxy_server_current_queue{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_current_queue{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_current_queue{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_current_session_rate Current number of sessions per second over last elapsed second.
 # TYPE haproxy_server_current_session_rate gauge
-haproxy_server_current_session_rate{backend="foo",server="BACKEND"} 0
-haproxy_server_current_session_rate{backend="foo",server="FRONTEND"} 0
-haproxy_server_current_session_rate{backend="foo",server="foo-instance-0"} 0
+haproxy_server_current_session_rate{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_current_session_rate{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_current_session_rate{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_current_sessions Current number of active sessions.
 # TYPE haproxy_server_current_sessions gauge
-haproxy_server_current_sessions{backend="foo",server="BACKEND"} 0
-haproxy_server_current_sessions{backend="foo",server="FRONTEND"} 0
-haproxy_server_current_sessions{backend="foo",server="foo-instance-0"} 0
+haproxy_server_current_sessions{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_current_sessions{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_current_sessions{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_downtime_seconds_total Total downtime in seconds.
 # TYPE haproxy_server_downtime_seconds_total gauge
-haproxy_server_downtime_seconds_total{backend="foo",server="BACKEND"} 0
-haproxy_server_downtime_seconds_total{backend="foo",server="FRONTEND"} 0
-haproxy_server_downtime_seconds_total{backend="foo",server="foo-instance-0"} 0
+haproxy_server_downtime_seconds_total{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_downtime_seconds_total{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_downtime_seconds_total{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_max_queue Maximum observed number of queued requests assigned to this server.
 # TYPE haproxy_server_max_queue gauge
-haproxy_server_max_queue{backend="foo",server="BACKEND"} 0
-haproxy_server_max_queue{backend="foo",server="FRONTEND"} 0
-haproxy_server_max_queue{backend="foo",server="foo-instance-0"} 0
+haproxy_server_max_queue{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_max_queue{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_max_queue{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_max_session_rate Maximum observed number of sessions per second.
 # TYPE haproxy_server_max_session_rate gauge
-haproxy_server_max_session_rate{backend="foo",server="BACKEND"} 0
-haproxy_server_max_session_rate{backend="foo",server="FRONTEND"} 0
-haproxy_server_max_session_rate{backend="foo",server="foo-instance-0"} 0
+haproxy_server_max_session_rate{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_max_session_rate{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_max_session_rate{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_max_sessions Maximum observed number of active sessions.
 # TYPE haproxy_server_max_sessions gauge
-haproxy_server_max_sessions{backend="foo",server="BACKEND"} 0
-haproxy_server_max_sessions{backend="foo",server="FRONTEND"} 0
-haproxy_server_max_sessions{backend="foo",server="foo-instance-0"} 0
+haproxy_server_max_sessions{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_max_sessions{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_max_sessions{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_redispatch_warnings_total Total of redispatch warnings.
 # TYPE haproxy_server_redispatch_warnings_total gauge
-haproxy_server_redispatch_warnings_total{backend="foo",server="BACKEND"} 0
-haproxy_server_redispatch_warnings_total{backend="foo",server="FRONTEND"} 0
-haproxy_server_redispatch_warnings_total{backend="foo",server="foo-instance-0"} 0
+haproxy_server_redispatch_warnings_total{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_redispatch_warnings_total{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_redispatch_warnings_total{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_response_errors_total Total of response errors.
 # TYPE haproxy_server_response_errors_total gauge
-haproxy_server_response_errors_total{backend="foo",server="BACKEND"} 0
-haproxy_server_response_errors_total{backend="foo",server="FRONTEND"} 0
-haproxy_server_response_errors_total{backend="foo",server="foo-instance-0"} 0
+haproxy_server_response_errors_total{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_response_errors_total{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_response_errors_total{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_retry_warnings_total Total of retry warnings.
 # TYPE haproxy_server_retry_warnings_total gauge
-haproxy_server_retry_warnings_total{backend="foo",server="BACKEND"} 0
-haproxy_server_retry_warnings_total{backend="foo",server="FRONTEND"} 0
-haproxy_server_retry_warnings_total{backend="foo",server="foo-instance-0"} 0
+haproxy_server_retry_warnings_total{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_retry_warnings_total{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_retry_warnings_total{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_server_selected_total Total number of times a server was selected, either for new sessions, or when re-dispatching.
 # TYPE haproxy_server_server_selected_total gauge
-haproxy_server_server_selected_total{backend="foo",server="BACKEND"} 0
-haproxy_server_server_selected_total{backend="foo",server="FRONTEND"} 0
-haproxy_server_server_selected_total{backend="foo",server="foo-instance-0"} 0
+haproxy_server_server_selected_total{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_server_selected_total{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_server_selected_total{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_sessions_total Total number of sessions.
 # TYPE haproxy_server_sessions_total gauge
-haproxy_server_sessions_total{backend="foo",server="BACKEND"} 0
-haproxy_server_sessions_total{backend="foo",server="FRONTEND"} 0
-haproxy_server_sessions_total{backend="foo",server="foo-instance-0"} 0
+haproxy_server_sessions_total{backend="foo",server="BACKEND",sid="1"} 0
+haproxy_server_sessions_total{backend="foo",server="FRONTEND",sid="1"} 0
+haproxy_server_sessions_total{backend="foo",server="foo-instance-0",sid="1"} 0
 # HELP haproxy_server_up Current health status of the server (1 = UP, 0 = DOWN).
 # TYPE haproxy_server_up gauge
-haproxy_server_up{backend="foo",server="BACKEND"} 1
-haproxy_server_up{backend="foo",server="FRONTEND"} 1
-haproxy_server_up{backend="foo",server="foo-instance-0"} 1
+haproxy_server_up{backend="foo",server="BACKEND",sid="1"} 1
+haproxy_server_up{backend="foo",server="FRONTEND",sid="1"} 1
+haproxy_server_up{backend="foo",server="foo-instance-0",sid="1"} 1
 # HELP haproxy_server_weight Current weight of the server.
 # TYPE haproxy_server_weight gauge
-haproxy_server_weight{backend="foo",server="BACKEND"} 1
-haproxy_server_weight{backend="foo",server="FRONTEND"} 1
-haproxy_server_weight{backend="foo",server="foo-instance-0"} 1
+haproxy_server_weight{backend="foo",server="BACKEND",sid="1"} 1
+haproxy_server_weight{backend="foo",server="FRONTEND",sid="1"} 1
+haproxy_server_weight{backend="foo",server="foo-instance-0",sid="1"} 1
 # HELP haproxy_up Was the last scrape of haproxy successful.
 # TYPE haproxy_up gauge
 haproxy_up 1

--- a/test/server_without_checks.metrics
+++ b/test/server_without_checks.metrics
@@ -6,69 +6,69 @@ haproxy_exporter_csv_parse_failures 0
 haproxy_exporter_total_scrapes 1
 # HELP haproxy_server_bytes_in_total Current total of incoming bytes.
 # TYPE haproxy_server_bytes_in_total gauge
-haproxy_server_bytes_in_total{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_bytes_in_total{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_bytes_out_total Current total of outgoing bytes.
 # TYPE haproxy_server_bytes_out_total gauge
-haproxy_server_bytes_out_total{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_bytes_out_total{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_check_failures_total Total number of failed health checks.
 # TYPE haproxy_server_check_failures_total gauge
-haproxy_server_check_failures_total{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_check_failures_total{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_connection_errors_total Total of connection errors.
 # TYPE haproxy_server_connection_errors_total gauge
-haproxy_server_connection_errors_total{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_connection_errors_total{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_current_queue Current number of queued requests assigned to this server.
 # TYPE haproxy_server_current_queue gauge
-haproxy_server_current_queue{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_current_queue{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_current_session_rate Current number of sessions per second over last elapsed second.
 # TYPE haproxy_server_current_session_rate gauge
-haproxy_server_current_session_rate{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_current_session_rate{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_current_sessions Current number of active sessions.
 # TYPE haproxy_server_current_sessions gauge
-haproxy_server_current_sessions{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_current_sessions{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_downtime_seconds_total Total downtime in seconds.
 # TYPE haproxy_server_downtime_seconds_total gauge
-haproxy_server_downtime_seconds_total{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_downtime_seconds_total{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_http_responses_total Total of HTTP responses.
 # TYPE haproxy_server_http_responses_total gauge
-haproxy_server_http_responses_total{backend="test",code="1xx",server="127.0.0.1:8080"} 0
-haproxy_server_http_responses_total{backend="test",code="2xx",server="127.0.0.1:8080"} 0
-haproxy_server_http_responses_total{backend="test",code="3xx",server="127.0.0.1:8080"} 0
-haproxy_server_http_responses_total{backend="test",code="4xx",server="127.0.0.1:8080"} 0
-haproxy_server_http_responses_total{backend="test",code="5xx",server="127.0.0.1:8080"} 0
-haproxy_server_http_responses_total{backend="test",code="other",server="127.0.0.1:8080"} 0
+haproxy_server_http_responses_total{backend="test",code="1xx",server="127.0.0.1:8080",sid="1"} 0
+haproxy_server_http_responses_total{backend="test",code="2xx",server="127.0.0.1:8080",sid="1"} 0
+haproxy_server_http_responses_total{backend="test",code="3xx",server="127.0.0.1:8080",sid="1"} 0
+haproxy_server_http_responses_total{backend="test",code="4xx",server="127.0.0.1:8080",sid="1"} 0
+haproxy_server_http_responses_total{backend="test",code="5xx",server="127.0.0.1:8080",sid="1"} 0
+haproxy_server_http_responses_total{backend="test",code="other",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_limit_sessions Configured session limit.
 # TYPE haproxy_server_limit_sessions gauge
-haproxy_server_limit_sessions{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_limit_sessions{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_max_queue Maximum observed number of queued requests assigned to this server.
 # TYPE haproxy_server_max_queue gauge
-haproxy_server_max_queue{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_max_queue{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_max_session_rate Maximum observed number of sessions per second.
 # TYPE haproxy_server_max_session_rate gauge
-haproxy_server_max_session_rate{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_max_session_rate{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_max_sessions Maximum observed number of active sessions.
 # TYPE haproxy_server_max_sessions gauge
-haproxy_server_max_sessions{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_max_sessions{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_redispatch_warnings_total Total of redispatch warnings.
 # TYPE haproxy_server_redispatch_warnings_total gauge
-haproxy_server_redispatch_warnings_total{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_redispatch_warnings_total{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_response_errors_total Total of response errors.
 # TYPE haproxy_server_response_errors_total gauge
-haproxy_server_response_errors_total{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_response_errors_total{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_retry_warnings_total Total of retry warnings.
 # TYPE haproxy_server_retry_warnings_total gauge
-haproxy_server_retry_warnings_total{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_retry_warnings_total{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_server_selected_total Total number of times a server was selected, either for new sessions, or when re-dispatching.
 # TYPE haproxy_server_server_selected_total gauge
-haproxy_server_server_selected_total{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_server_selected_total{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_sessions_total Total number of sessions.
 # TYPE haproxy_server_sessions_total gauge
-haproxy_server_sessions_total{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_sessions_total{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_up Current health status of the server (1 = UP, 0 = DOWN).
 # TYPE haproxy_server_up gauge
-haproxy_server_up{backend="test",server="127.0.0.1:8080"} 1
+haproxy_server_up{backend="test",server="127.0.0.1:8080",sid="1"} 1
 # HELP haproxy_server_weight Current weight of the server.
 # TYPE haproxy_server_weight gauge
-haproxy_server_weight{backend="test",server="127.0.0.1:8080"} 1
+haproxy_server_weight{backend="test",server="127.0.0.1:8080",sid="1"} 1
 # HELP haproxy_up Was the last scrape of haproxy successful.
 # TYPE haproxy_up gauge
 haproxy_up 1

--- a/test/unix_domain.metrics
+++ b/test/unix_domain.metrics
@@ -6,69 +6,69 @@ haproxy_exporter_csv_parse_failures 0
 haproxy_exporter_total_scrapes 1
 # HELP haproxy_server_bytes_in_total Current total of incoming bytes.
 # TYPE haproxy_server_bytes_in_total gauge
-haproxy_server_bytes_in_total{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_bytes_in_total{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_bytes_out_total Current total of outgoing bytes.
 # TYPE haproxy_server_bytes_out_total gauge
-haproxy_server_bytes_out_total{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_bytes_out_total{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_check_failures_total Total number of failed health checks.
 # TYPE haproxy_server_check_failures_total gauge
-haproxy_server_check_failures_total{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_check_failures_total{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_connection_errors_total Total of connection errors.
 # TYPE haproxy_server_connection_errors_total gauge
-haproxy_server_connection_errors_total{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_connection_errors_total{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_current_queue Current number of queued requests assigned to this server.
 # TYPE haproxy_server_current_queue gauge
-haproxy_server_current_queue{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_current_queue{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_current_session_rate Current number of sessions per second over last elapsed second.
 # TYPE haproxy_server_current_session_rate gauge
-haproxy_server_current_session_rate{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_current_session_rate{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_current_sessions Current number of active sessions.
 # TYPE haproxy_server_current_sessions gauge
-haproxy_server_current_sessions{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_current_sessions{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_downtime_seconds_total Total downtime in seconds.
 # TYPE haproxy_server_downtime_seconds_total gauge
-haproxy_server_downtime_seconds_total{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_downtime_seconds_total{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_http_responses_total Total of HTTP responses.
 # TYPE haproxy_server_http_responses_total gauge
-haproxy_server_http_responses_total{backend="test",code="1xx",server="127.0.0.1:8080"} 0
-haproxy_server_http_responses_total{backend="test",code="2xx",server="127.0.0.1:8080"} 0
-haproxy_server_http_responses_total{backend="test",code="3xx",server="127.0.0.1:8080"} 0
-haproxy_server_http_responses_total{backend="test",code="4xx",server="127.0.0.1:8080"} 0
-haproxy_server_http_responses_total{backend="test",code="5xx",server="127.0.0.1:8080"} 0
-haproxy_server_http_responses_total{backend="test",code="other",server="127.0.0.1:8080"} 0
+haproxy_server_http_responses_total{backend="test",code="1xx",server="127.0.0.1:8080",sid="1"} 0
+haproxy_server_http_responses_total{backend="test",code="2xx",server="127.0.0.1:8080",sid="1"} 0
+haproxy_server_http_responses_total{backend="test",code="3xx",server="127.0.0.1:8080",sid="1"} 0
+haproxy_server_http_responses_total{backend="test",code="4xx",server="127.0.0.1:8080",sid="1"} 0
+haproxy_server_http_responses_total{backend="test",code="5xx",server="127.0.0.1:8080",sid="1"} 0
+haproxy_server_http_responses_total{backend="test",code="other",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_limit_sessions Configured session limit.
 # TYPE haproxy_server_limit_sessions gauge
-haproxy_server_limit_sessions{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_limit_sessions{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_max_queue Maximum observed number of queued requests assigned to this server.
 # TYPE haproxy_server_max_queue gauge
-haproxy_server_max_queue{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_max_queue{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_max_session_rate Maximum observed number of sessions per second.
 # TYPE haproxy_server_max_session_rate gauge
-haproxy_server_max_session_rate{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_max_session_rate{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_max_sessions Maximum observed number of active sessions.
 # TYPE haproxy_server_max_sessions gauge
-haproxy_server_max_sessions{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_max_sessions{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_redispatch_warnings_total Total of redispatch warnings.
 # TYPE haproxy_server_redispatch_warnings_total gauge
-haproxy_server_redispatch_warnings_total{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_redispatch_warnings_total{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_response_errors_total Total of response errors.
 # TYPE haproxy_server_response_errors_total gauge
-haproxy_server_response_errors_total{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_response_errors_total{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_retry_warnings_total Total of retry warnings.
 # TYPE haproxy_server_retry_warnings_total gauge
-haproxy_server_retry_warnings_total{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_retry_warnings_total{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_server_selected_total Total number of times a server was selected, either for new sessions, or when re-dispatching.
 # TYPE haproxy_server_server_selected_total gauge
-haproxy_server_server_selected_total{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_server_selected_total{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_sessions_total Total number of sessions.
 # TYPE haproxy_server_sessions_total gauge
-haproxy_server_sessions_total{backend="test",server="127.0.0.1:8080"} 0
+haproxy_server_sessions_total{backend="test",server="127.0.0.1:8080",sid="1"} 0
 # HELP haproxy_server_up Current health status of the server (1 = UP, 0 = DOWN).
 # TYPE haproxy_server_up gauge
-haproxy_server_up{backend="test",server="127.0.0.1:8080"} 1
+haproxy_server_up{backend="test",server="127.0.0.1:8080",sid="1"} 1
 # HELP haproxy_server_weight Current weight of the server.
 # TYPE haproxy_server_weight gauge
-haproxy_server_weight{backend="test",server="127.0.0.1:8080"} 1
+haproxy_server_weight{backend="test",server="127.0.0.1:8080",sid="1"} 1
 # HELP haproxy_up Was the last scrape of haproxy successful.
 # TYPE haproxy_up gauge
 haproxy_up 1


### PR DESCRIPTION
When having the same backend on the same host the exporter crashes.

https://www.haproxy.org/download/1.6/doc/management.txt
```
 27. iid [LFBS]: unique proxy id
 28. sid [L..S]: server id (unique inside a proxy)
```